### PR TITLE
Add flag to disable page speed for charts Khan/gae_mini_profiler#72

### DIFF
--- a/static/chrome/profile.html
+++ b/static/chrome/profile.html
@@ -97,6 +97,6 @@ function DevToolsLoaded() {
   });
 }
 </script>
-<iframe id="devtools" frameborder="0" height="100%" width="100%" src="/gae_mini_profiler/static/chrome/inspector-20140603/devtools.html" onload="DevToolsLoaded();"></iframe>
+<iframe id="devtools" frameborder="0" height="100%" width="100%" src="/gae_mini_profiler/static/chrome/inspector-20140603/devtools.html?ModPagespeed=off" onload="DevToolsLoaded();"></iframe>
 </body>
 </html>

--- a/static/js/template.tmpl
+++ b/static/js/template.tmpl
@@ -170,7 +170,7 @@
             <div class="sampling-profiler-help">
                 {{if navigator.userAgent.indexOf("Chrome/") !== -1}}
                 <a target="_cpuprofile"
-                   href="/gae_mini_profiler/static/chrome/profile.html?request_id=${encodeURIComponent(request_id)}"
+                   href="/gae_mini_profiler/static/chrome/profile.html?ModPagespeed=off&request_id=${encodeURIComponent(request_id)}"
                    title="View the profile as a flame chart.">
                     Visualize
                 </a>


### PR DESCRIPTION
With page speed enabled gae_mini_profiler/static/chrome/profile.html
will not work at all.
